### PR TITLE
Fix case titles and descriptions

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Users, FileText, DollarSign, TrendingUp, Settings, Plus, MoreHorizontal, Shield } from "lucide-react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { supabase, type Case, type Profile } from "@/lib/supabase"
+import { formatCaseText } from "@/lib/utils"
 
 export default function AdminDashboard() {
   const [cases, setCases] = useState<Case[]>([])
@@ -216,7 +217,7 @@ export default function AdminDashboard() {
                     {cases.slice(0, 5).map((case_) => (
                       <TableRow key={case_.id} className="border-slate-700">
                         <TableCell className="text-slate-300 font-mono">{case_.case_number}</TableCell>
-                        <TableCell className="text-white">{case_.title}</TableCell>
+                        <TableCell className="text-white">{formatCaseText(case_.title)}</TableCell>
                         <TableCell>
                           <Badge variant="outline" className="border-orange-500 text-orange-400 capitalize">
                             {case_.category}

--- a/app/dashboard/ethics-officer/page.tsx
+++ b/app/dashboard/ethics-officer/page.tsx
@@ -64,6 +64,7 @@ import { DashboardLayout } from "@/components/dashboard-layout";
 import { supabase, type Case, type Profile } from "@/lib/supabase";
 import { cryptoRewardSystem, supportedCurrencies } from "@/lib/crypto-utils";
 import { auditLogger } from "@/lib/audit-logger";
+import { formatCaseText } from "@/lib/utils";
 
 export default function EthicsOfficerDashboard() {
   const [cases, setCases] = useState<Case[]>([]);
@@ -935,11 +936,11 @@ export default function EthicsOfficerDashboard() {
                             {case_.report_id || case_.case_number}
                           </TableCell>
                           <TableCell className="text-white max-w-xs truncate">
-                            {case_.title}
+                            {formatCaseText(case_.title)}
                           </TableCell>
                           <TableCell className="text-slate-300 max-w-sm">
                             <span className="truncate block">
-                              {case_.vapi_report_summary || case_.description}
+                              {formatCaseText(case_.vapi_report_summary || case_.description)}
                             </span>
                             <Dialog>
                               <DialogTrigger asChild>
@@ -1277,7 +1278,7 @@ export default function EthicsOfficerDashboard() {
                               {case_.case_number}
                             </TableCell>
                             <TableCell className="text-white">
-                              {case_.title}
+                              {formatCaseText(case_.title)}
                             </TableCell>
                             <TableCell className="text-green-400">
                               ${case_.recovery_amount?.toLocaleString() || "0"}
@@ -1347,12 +1348,12 @@ export default function EthicsOfficerDashboard() {
                 </div>
                 <div>
                   <Label className="text-slate-300">Title</Label>
-                  <p className="text-white">{selectedCase.title}</p>
+                  <p className="text-white">{formatCaseText(selectedCase.title)}</p>
                 </div>
                 <div>
                   <Label className="text-slate-300">Description</Label>
                   <div className="bg-slate-900/50 p-3 rounded border border-slate-600">
-                    <p className="text-slate-300">{selectedCase.description}</p>
+                    <p className="text-slate-300">{formatCaseText(selectedCase.description)}</p>
                   </div>
                 </div>
                 {selectedCase.vapi_transcript && (

--- a/app/dashboard/investigator/page.tsx
+++ b/app/dashboard/investigator/page.tsx
@@ -44,6 +44,7 @@ import {
 import { DashboardLayout } from "@/components/dashboard-layout";
 import { supabase, type Case, type InvestigatorQuery } from "@/lib/supabase";
 import { auditLogger } from "@/lib/audit-logger";
+import { formatCaseText } from "@/lib/utils";
 
 export default function InvestigatorDashboard() {
   const [cases, setCases] = useState<Case[]>([]);
@@ -362,10 +363,10 @@ export default function InvestigatorDashboard() {
                           {case_.report_id || case_.case_number}
                         </TableCell>
                         <TableCell className="text-white max-w-xs truncate">
-                          {case_.title}
+                          {formatCaseText(case_.title)}
                         </TableCell>
                         <TableCell className="text-slate-300 max-w-sm truncate">
-                          {case_.vapi_report_summary || case_.description}
+                          {formatCaseText(case_.vapi_report_summary || case_.description)}
                         </TableCell>
                         <TableCell>
                           <Badge

--- a/app/follow-up/page.tsx
+++ b/app/follow-up/page.tsx
@@ -36,6 +36,7 @@ import {
   type CaseUpdate,
   type InvestigatorQuery,
 } from "@/lib/supabase";
+import { formatCaseText } from "@/lib/utils";
 
 export default function FollowUpPage() {
   const [secretCode, setSecretCode] = useState("");
@@ -282,7 +283,7 @@ export default function FollowUpPage() {
                 <div className="flex justify-between items-start">
                   <div>
                     <CardTitle className="text-white">
-                      {caseData.title}
+                      {formatCaseText(caseData.title)}
                     </CardTitle>
                     <CardDescription className="text-slate-400">
                       Report ID: {caseData.report_id || caseData.case_number} •

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,34 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatCaseText(field: any): string {
+  if (field === null || field === undefined) return ""
+
+  let value: any = field
+
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+      try {
+        value = JSON.parse(trimmed)
+      } catch {
+        return value
+      }
+    } else {
+      return value
+    }
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return (
+      value.title ||
+      value.detailed_description ||
+      value.description ||
+      (value.incident && (value.incident.description || value.incident.summary)) ||
+      ""
+    )
+  }
+
+  return String(value)
+}


### PR DESCRIPTION
## Summary
- handle cases where title/description are stored as JSON objects
- display parsed values in dashboards and follow‑up page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e5b70b884832f86fbbb681af2b2c7