### PR TITLE
Fix case titles and show location/date

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -9,6 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Users, FileText, DollarSign, TrendingUp, Settings, Plus, MoreHorizontal, Shield } from "lucide-react"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { supabase, type Case, type Profile } from "@/lib/supabase"
+import { formatCaseText, formatCaseTitle } from "@/lib/utils"
 
 export default function AdminDashboard() {
   const [cases, setCases] = useState<Case[]>([])
@@ -216,7 +217,7 @@ export default function AdminDashboard() {
                     {cases.slice(0, 5).map((case_) => (
                       <TableRow key={case_.id} className="border-slate-700">
                         <TableCell className="text-slate-300 font-mono">{case_.case_number}</TableCell>
-                        <TableCell className="text-white">{case_.title}</TableCell>
+                        <TableCell className="text-white">{formatCaseTitle(case_.title, case_.description, case_.created_at)}</TableCell>
                         <TableCell>
                           <Badge variant="outline" className="border-orange-500 text-orange-400 capitalize">
                             {case_.category}

--- a/app/dashboard/ethics-officer/page.tsx
+++ b/app/dashboard/ethics-officer/page.tsx
@@ -64,6 +64,7 @@ import { DashboardLayout } from "@/components/dashboard-layout";
 import { supabase, type Case, type Profile } from "@/lib/supabase";
 import { cryptoRewardSystem, supportedCurrencies } from "@/lib/crypto-utils";
 import { auditLogger } from "@/lib/audit-logger";
+import { formatCaseText, formatCaseTitle, extractCaseLocation, getCaseDateReceived } from "@/lib/utils";
 
 export default function EthicsOfficerDashboard() {
   const [cases, setCases] = useState<Case[]>([]);
@@ -935,11 +936,11 @@ export default function EthicsOfficerDashboard() {
                             {case_.report_id || case_.case_number}
                           </TableCell>
                           <TableCell className="text-white max-w-xs truncate">
-                            {case_.title}
+                            {formatCaseTitle(case_.title, case_.description, case_.created_at)}
                           </TableCell>
                           <TableCell className="text-slate-300 max-w-sm">
                             <span className="truncate block">
-                              {case_.vapi_report_summary || case_.description}
+                              {formatCaseText(case_.vapi_report_summary || case_.description)}
                             </span>
                             <Dialog>
                               <DialogTrigger asChild>
@@ -1277,7 +1278,7 @@ export default function EthicsOfficerDashboard() {
                               {case_.case_number}
                             </TableCell>
                             <TableCell className="text-white">
-                              {case_.title}
+                              {formatCaseTitle(case_.title, case_.description, case_.created_at)}
                             </TableCell>
                             <TableCell className="text-green-400">
                               ${case_.recovery_amount?.toLocaleString() || "0"}
@@ -1345,14 +1346,30 @@ export default function EthicsOfficerDashboard() {
                     </p>
                   </div>
                 </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label className="text-slate-300">Date Received</Label>
+                    <p className="text-white">
+                      {getCaseDateReceived(selectedCase.title, selectedCase.description, selectedCase.created_at)}
+                    </p>
+                  </div>
+                  <div>
+                    <Label className="text-slate-300">Location</Label>
+                    <p className="text-white">
+                      {extractCaseLocation(selectedCase.title) || extractCaseLocation(selectedCase.description)}
+                    </p>
+                  </div>
+                </div>
                 <div>
                   <Label className="text-slate-300">Title</Label>
-                  <p className="text-white">{selectedCase.title}</p>
+                  <p className="text-white">
+                    {formatCaseTitle(selectedCase.title, selectedCase.description, selectedCase.created_at)}
+                  </p>
                 </div>
                 <div>
                   <Label className="text-slate-300">Description</Label>
                   <div className="bg-slate-900/50 p-3 rounded border border-slate-600">
-                    <p className="text-slate-300">{selectedCase.description}</p>
+                    <p className="text-slate-300">{formatCaseText(selectedCase.description)}</p>
                   </div>
                 </div>
                 {selectedCase.vapi_transcript && (

--- a/app/dashboard/investigator/page.tsx
+++ b/app/dashboard/investigator/page.tsx
@@ -44,6 +44,7 @@ import {
 import { DashboardLayout } from "@/components/dashboard-layout";
 import { supabase, type Case, type InvestigatorQuery } from "@/lib/supabase";
 import { auditLogger } from "@/lib/audit-logger";
+import { formatCaseText, formatCaseTitle } from "@/lib/utils";
 
 export default function InvestigatorDashboard() {
   const [cases, setCases] = useState<Case[]>([]);
@@ -362,10 +363,10 @@ export default function InvestigatorDashboard() {
                           {case_.report_id || case_.case_number}
                         </TableCell>
                         <TableCell className="text-white max-w-xs truncate">
-                          {case_.title}
+                          {formatCaseTitle(case_.title, case_.description, case_.created_at)}
                         </TableCell>
                         <TableCell className="text-slate-300 max-w-sm truncate">
-                          {case_.vapi_report_summary || case_.description}
+                          {formatCaseText(case_.vapi_report_summary || case_.description)}
                         </TableCell>
                         <TableCell>
                           <Badge

--- a/app/follow-up/page.tsx
+++ b/app/follow-up/page.tsx
@@ -36,6 +36,7 @@ import {
   type CaseUpdate,
   type InvestigatorQuery,
 } from "@/lib/supabase";
+import { formatCaseText, formatCaseTitle, getCaseDateReceived, extractCaseLocation } from "@/lib/utils";
 
 export default function FollowUpPage() {
   const [secretCode, setSecretCode] = useState("");
@@ -282,7 +283,7 @@ export default function FollowUpPage() {
                 <div className="flex justify-between items-start">
                   <div>
                     <CardTitle className="text-white">
-                      {caseData.title}
+                      {formatCaseTitle(caseData.title, caseData.description, caseData.created_at)}
                     </CardTitle>
                     <CardDescription className="text-slate-400">
                       Report ID: {caseData.report_id || caseData.case_number} •
@@ -327,6 +328,20 @@ export default function FollowUpPage() {
                         {getProgress(caseData.status)}%
                       </span>
                     </div>
+                  </div>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <span className="text-slate-400 text-sm">Date Received</span>
+                    <p className="text-white">
+                      {getCaseDateReceived(caseData.title, caseData.description, caseData.created_at)}
+                    </p>
+                  </div>
+                  <div>
+                    <span className="text-slate-400 text-sm">Location</span>
+                    <p className="text-white">
+                      {extractCaseLocation(caseData.title) || extractCaseLocation(caseData.description)}
+                    </p>
                   </div>
                 </div>
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,117 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatCaseText(field: any): string {
+  if (field === null || field === undefined) return ""
+
+  let value: any = field
+
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+      try {
+        value = JSON.parse(trimmed)
+      } catch {
+        return value
+      }
+    } else {
+      return value
+    }
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return (
+      value.title ||
+      value.detailed_description ||
+      value.description ||
+      (value.incident && (value.incident.description || value.incident.summary)) ||
+      ""
+    )
+  }
+
+  return String(value)
+}
+
+export function parseCaseData(field: any): any | null {
+  if (field === null || field === undefined) return null
+
+  let value: any = field
+
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+      try {
+        value = JSON.parse(trimmed)
+      } catch {
+        return null
+      }
+    } else {
+      return null
+    }
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return value
+  }
+
+  return null
+}
+
+export function extractCaseLocation(field: any): string {
+  const data = parseCaseData(field)
+  if (!data) return ""
+
+  return (
+    data.location ||
+    (data.incident && data.incident.location) ||
+    (data.structuredData && data.structuredData.location) ||
+    ""
+  )
+}
+
+export function extractCaseDate(field: any): string {
+  const data = parseCaseData(field)
+  if (!data) return ""
+
+  return (
+    data.date_received ||
+    data.date ||
+    (data.incident && (data.incident.date || data.incident.date_received)) ||
+    ""
+  )
+}
+
+export function getCaseDateReceived(
+  titleField: any,
+  descriptionField?: any,
+  createdAt?: string,
+): string {
+  const rawDate =
+    extractCaseDate(titleField) ||
+    extractCaseDate(descriptionField) ||
+    createdAt ||
+    ""
+
+  if (!rawDate) return ""
+
+  const dateObj = new Date(rawDate)
+  if (isNaN(dateObj.getTime())) return String(rawDate)
+  return dateObj.toLocaleDateString()
+}
+
+export function formatCaseTitle(
+  titleField: any,
+  descriptionField?: any,
+  createdAt?: string,
+): string {
+  const location =
+    extractCaseLocation(titleField) || extractCaseLocation(descriptionField)
+  const date = getCaseDateReceived(titleField, descriptionField, createdAt)
+
+  if (location && date) return `${location} - ${date}`
+  if (location) return location
+  if (date) return date
+
+  return formatCaseText(titleField)
+}


### PR DESCRIPTION
## Summary
- add helpers to parse case JSON and build titles from location and date
- use the new title format in dashboard and follow-up pages
- show Date Received and Location fields in case details dialog

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_683e5b70b884832f86fbbb681af2b2c7