### PR TITLE
Improve case detail parsing

### DIFF
--- a/app/dashboard/ethics-officer/page.tsx
+++ b/app/dashboard/ethics-officer/page.tsx
@@ -92,6 +92,38 @@ export default function EthicsOfficerDashboard() {
   const [escalationNote, setEscalationNote] = useState("");
   const [error, setError] = useState<string | null>(null);
 
+  const normalizeCase = (c: any): Case => {
+    const normalized = { ...c } as Case;
+
+    const tryParse = (val: any): any => {
+      if (!val) return null;
+      if (typeof val === "object") return val;
+      if (typeof val === "string") {
+        try {
+          return JSON.parse(val);
+        } catch {
+          return null;
+        }
+      }
+      return null;
+    };
+
+    const parsed = tryParse(c.description) || tryParse(c.title);
+
+    if (parsed && parsed.incident) {
+      normalized.structured_data = parsed;
+      const location = parsed.incident.location || "Unknown";
+      normalized.title = `${location} - TESTING`;
+      normalized.description = parsed.incident.description || "";
+    } else {
+      normalized.title = typeof c.title === "string" ? c.title : "";
+      normalized.description =
+        typeof c.description === "string" ? c.description : "";
+    }
+
+    return normalized;
+  };
+
   useEffect(() => {
     fetchData();
     fetchVAPIReports();
@@ -214,7 +246,8 @@ export default function EthicsOfficerDashboard() {
             ? investigatorsData
             : mockInvestigators;
 
-        setCases(finalCases);
+        const normalized = finalCases.map((c) => normalizeCase(c));
+        setCases(normalized);
         setInvestigators(finalInvestigators);
 
         // Calculate stats
@@ -241,7 +274,7 @@ export default function EthicsOfficerDashboard() {
         );
       } catch (dbError) {
         console.warn("Database not available, using mock data:", dbError);
-        setCases(mockCases);
+        setCases(mockCases.map((c) => normalizeCase(c)));
         setInvestigators(mockInvestigators);
 
         // Calculate stats from mock data
@@ -360,8 +393,8 @@ export default function EthicsOfficerDashboard() {
             updated_at: new Date().toISOString(),
           };
 
-          // Add to local state
-          setCases((prevCases) => [newCase, ...prevCases]);
+          // Add to local state with normalization
+          setCases((prevCases) => [normalizeCase(newCase), ...prevCases]);
 
           // Try to save to database (optional)
           try {
@@ -432,7 +465,7 @@ export default function EthicsOfficerDashboard() {
       };
 
       // Add to local state
-      setCases((prevCases) => [newCase, ...prevCases]);
+      setCases((prevCases) => [normalizeCase(newCase), ...prevCases]);
 
       // Try to save to database
       try {
@@ -1355,6 +1388,32 @@ export default function EthicsOfficerDashboard() {
                     <p className="text-slate-300">{selectedCase.description}</p>
                   </div>
                 </div>
+                {selectedCase.structured_data && (
+                  <>
+                    <div className="grid grid-cols-2 gap-4">
+                      <div>
+                        <Label className="text-slate-300">Incident Type</Label>
+                        <p className="text-white">
+                          {selectedCase.structured_data.incident?.type || "N/A"}
+                        </p>
+                      </div>
+                      <div>
+                        <Label className="text-slate-300">Incident Date</Label>
+                        <p className="text-white">
+                          {selectedCase.structured_data.incident?.date || "N/A"}
+                        </p>
+                      </div>
+                    </div>
+                    <div>
+                      <Label className="text-slate-300">Follow Up Notes</Label>
+                      <div className="bg-slate-900/50 p-3 rounded border border-slate-600">
+                        <p className="text-slate-300">
+                          {selectedCase.structured_data.follow_up?.notes || "N/A"}
+                        </p>
+                      </div>
+                    </div>
+                  </>
+                )}
                 {selectedCase.vapi_transcript && (
                   <div>
                     <Label className="text-slate-300">Voice Transcript</Label>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -33,6 +33,7 @@ export interface Case {
   vapi_session_id?: string;
   vapi_transcript?: string; // NEW
   vapi_audio_url?: string; // NEW
+  structured_data?: any; // Parsed VAPI fields
   assigned_to?: string;
   assigned_by?: string; // NEW
   resolution_summary?: string; // NEW


### PR DESCRIPTION
## Summary
- normalize case fields when pulling data from Supabase
- store parsed VAPI structured data in `structured_data`
- display parsed incident fields in case detail dialog

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_b_683e69d9c580832f89298290a5b7b65e