### PR TITLE
Clean up duplicate formatCaseText implementation

### DIFF
--- a/app/dashboard/investigator/page.tsx
+++ b/app/dashboard/investigator/page.tsx
@@ -47,9 +47,6 @@ import { auditLogger } from "@/lib/audit-logger";
 import { formatCaseText, formatCaseTitle } from "@/lib/utils";
 
 
-import { formatCaseText, formatCaseTitle } from "@/lib/utils";
-
-
 
 export default function InvestigatorDashboard() {
   const [cases, setCases] = useState<Case[]>([]);

--- a/app/follow-up/page.tsx
+++ b/app/follow-up/page.tsx
@@ -39,9 +39,6 @@ import {
 import { formatCaseText, formatCaseTitle, getCaseDateReceived, extractCaseLocation } from "@/lib/utils";
 
 
-import { formatCaseText, formatCaseTitle, getCaseDateReceived, extractCaseLocation } from "@/lib/utils";
-
-
 
 export default function FollowUpPage() {
   const [secretCode, setSecretCode] = useState("");

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,25 +16,6 @@ export function formatCaseText(field: any): string {
       try {
         value = JSON.parse(trimmed)
       } catch {
-
-        return trimmed
-      }
-    } else {
-      return trimmed
-    }
-  }
-
-export function formatCaseText(field: any): string {
-  if (field === null || field === undefined) return ""
-
-  let value: any = field
-
-  if (typeof value === "string") {
-    const trimmed = value.trim()
-    if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
-      try {
-        value = JSON.parse(trimmed)
-      } catch {
         return trimmed
       }
     } else {


### PR DESCRIPTION
## Summary
- remove obsolete formatCaseText implementation
- ensure a single import for utilities in dashboard pages

## Testing
- `tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react', ...)*

------
https://chatgpt.com/codex/tasks/task_b_683e76a17a64832f9a9ed90dff6310eb