### PR TITLE
Fix dashboard description display

### DIFF
--- a/app/dashboard/ethics-officer/page.tsx
+++ b/app/dashboard/ethics-officer/page.tsx
@@ -571,6 +571,25 @@ export default function EthicsOfficerDashboard() {
     return null;
   };
 
+  const getCaseDescription = (caseItem: Case) => {
+    if (caseItem.vapi_report_summary) return caseItem.vapi_report_summary;
+    const desc = caseItem.description as any;
+    if (typeof desc === "object" && desc !== null && desc.description) {
+      return desc.description;
+    }
+    if (typeof desc === "string") {
+      try {
+        const parsed = JSON.parse(desc);
+        if (parsed && typeof parsed === "object" && parsed.description) {
+          return parsed.description;
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+    return caseItem.description;
+  };
+
   const handleAssignCase = async (caseId: string, investigatorId: string) => {
     try {
       // Update local state immediately
@@ -958,7 +977,7 @@ export default function EthicsOfficerDashboard() {
                           </TableCell>
                           <TableCell className="text-slate-300 max-w-sm">
                             <span className="truncate block">
-                              {case_.vapi_report_summary || case_.description}
+                              {getCaseDescription(case_)}
                             </span>
                             <Dialog>
                               <DialogTrigger asChild>

--- a/app/dashboard/investigator/page.tsx
+++ b/app/dashboard/investigator/page.tsx
@@ -234,6 +234,25 @@ export default function InvestigatorDashboard() {
     }
   };
 
+  const getCaseDescription = (caseItem: Case) => {
+    if (caseItem.vapi_report_summary) return caseItem.vapi_report_summary;
+    const desc = caseItem.description as any;
+    if (typeof desc === "object" && desc !== null && desc.description) {
+      return desc.description;
+    }
+    if (typeof desc === "string") {
+      try {
+        const parsed = JSON.parse(desc);
+        if (parsed && typeof parsed === "object" && parsed.description) {
+          return parsed.description;
+        }
+      } catch {
+        // ignore
+      }
+    }
+    return caseItem.description;
+  };
+
   if (loading) {
     return (
       <DashboardLayout role="investigator">
@@ -365,7 +384,7 @@ export default function InvestigatorDashboard() {
                           {case_.title}
                         </TableCell>
                         <TableCell className="text-slate-300 max-w-sm truncate">
-                          {case_.vapi_report_summary || case_.description}
+                          {getCaseDescription(case_)}
                         </TableCell>
                         <TableCell>
                           <Badge


### PR DESCRIPTION
## Summary
- ensure case tables parse description from nested JSON

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f39be5b24832f88c424bd87916247