### PR TITLE
Add VAPI tracking code support

### DIFF
--- a/app/dashboard/admin/page.tsx
+++ b/app/dashboard/admin/page.tsx
@@ -205,7 +205,7 @@ export default function AdminDashboard() {
                 <Table>
                   <TableHeader>
                     <TableRow className="border-slate-700">
-                      <TableHead className="text-slate-300">Case #</TableHead>
+                      <TableHead className="text-slate-300">Case ID</TableHead>
                       <TableHead className="text-slate-300">Title</TableHead>
                       <TableHead className="text-slate-300">Category</TableHead>
                       <TableHead className="text-slate-300">Status</TableHead>
@@ -217,7 +217,7 @@ export default function AdminDashboard() {
                   <TableBody>
                     {cases.slice(0, 5).map((case_) => (
                       <TableRow key={case_.id} className="border-slate-700">
-                        <TableCell className="text-slate-300 font-mono">{case_.case_number}</TableCell>
+                        <TableCell className="text-slate-300 font-mono">{case_.tracking_code || case_.report_id || case_.case_number}</TableCell>
 
 
 

--- a/app/dashboard/ethics-officer/page.tsx
+++ b/app/dashboard/ethics-officer/page.tsx
@@ -375,12 +375,15 @@ export default function EthicsOfficerDashboard() {
           report.transcript.length > 20
         ) {
           // Create new case from VAPI report
+          const match = report.summary?.match(/tracking code[:\s]+([A-Z0-9]+)/i);
+
           const newCase: Case = {
             id: `case-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
             case_number: `WB-${new Date().getFullYear()}-${String(
               Math.floor(Math.random() * 10000)
             ).padStart(4, "0")}`,
             report_id: report.report_id,
+            tracking_code: match ? match[1] : undefined,
             title: extractTitleFromSummary(report.summary),
             description: report.summary,
             category: categorizeReport(report.summary, report.transcript),
@@ -446,12 +449,15 @@ export default function EthicsOfficerDashboard() {
         return;
       }
 
+      const match = report.summary?.match(/tracking code[:\s]+([A-Z0-9]+)/i);
+
       const newCase: Case = {
         id: `case-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
         case_number: `WB-${new Date().getFullYear()}-${String(
           Math.floor(Math.random() * 10000)
         ).padStart(4, "0")}`,
         report_id: report.report_id,
+        tracking_code: match ? match[1] : undefined,
         title: extractTitleFromSummary(report.summary),
         description: report.summary,
         category: categorizeReport(report.summary, report.transcript),
@@ -947,7 +953,7 @@ export default function EthicsOfficerDashboard() {
                   <Table>
                     <TableHeader>
                       <TableRow className="border-slate-700">
-                        <TableHead className="text-slate-300">ID</TableHead>
+                        <TableHead className="text-slate-300">Case ID</TableHead>
                         <TableHead className="text-slate-300">Title</TableHead>
                         <TableHead className="text-slate-300">
                           Summary
@@ -968,7 +974,7 @@ export default function EthicsOfficerDashboard() {
                       {cases.map((case_) => (
                         <TableRow key={case_.id} className="border-slate-700">
                           <TableCell className="text-slate-300 font-mono">
-                            {case_.report_id || case_.case_number}
+                            {case_.tracking_code || case_.report_id || case_.case_number}
                           </TableCell>
                           <TableCell className="text-white max-w-xs truncate">
 
@@ -1294,7 +1300,7 @@ export default function EthicsOfficerDashboard() {
                   <Table>
                     <TableHeader>
                       <TableRow className="border-slate-700">
-                        <TableHead className="text-slate-300">Case #</TableHead>
+                        <TableHead className="text-slate-300">Case ID</TableHead>
                         <TableHead className="text-slate-300">Title</TableHead>
                         <TableHead className="text-slate-300">
                           Recovery Amount
@@ -1316,7 +1322,7 @@ export default function EthicsOfficerDashboard() {
                         .map((case_) => (
                           <TableRow key={case_.id} className="border-slate-700">
                             <TableCell className="text-slate-300 font-mono">
-                              {case_.case_number}
+                              {case_.tracking_code || case_.report_id || case_.case_number}
                             </TableCell>
                             <TableCell className="text-white">
 

--- a/app/dashboard/investigator/page.tsx
+++ b/app/dashboard/investigator/page.tsx
@@ -350,7 +350,7 @@ export default function InvestigatorDashboard() {
                 <Table>
                   <TableHeader>
                     <TableRow className="border-slate-700">
-                      <TableHead className="text-slate-300">ID</TableHead>
+                      <TableHead className="text-slate-300">Case ID</TableHead>
                       <TableHead className="text-slate-300">Title</TableHead>
                       <TableHead className="text-slate-300">Summary</TableHead>
                       <TableHead className="text-slate-300">Category</TableHead>
@@ -362,7 +362,7 @@ export default function InvestigatorDashboard() {
                     {cases.map((case_) => (
                       <TableRow key={case_.id} className="border-slate-700">
                         <TableCell className="text-slate-300 font-mono">
-                          {case_.report_id || case_.case_number}
+                          {case_.tracking_code || case_.report_id || case_.case_number}
                         </TableCell>
                         <TableCell className="text-white max-w-xs truncate">
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -26,6 +26,7 @@ export interface Case {
   priority: "low" | "medium" | "high" | "critical";
   secret_code: string;
   report_id: string; // NEW: 10-digit alphanumeric ID
+  tracking_code?: string; // NEW optional tracking code from VAPI
   reward_amount?: number;
   recovery_amount?: number;
   reward_status: "pending" | "approved" | "paid";


### PR DESCRIPTION
## Summary
- extend `Case` interface with optional `tracking_code`
- extract tracking codes from VAPI report summaries
- show Case ID using tracking codes in ethics officer, investigator and admin tables

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fb427ea54832fa9886788474e4ddc