### PR TITLE
Use tracking codes for case references

### DIFF
--- a/app/dashboard/ethics-officer/page.tsx
+++ b/app/dashboard/ethics-officer/page.tsx
@@ -146,6 +146,7 @@ export default function EthicsOfficerDashboard() {
         {
           id: "case-1",
           case_number: "WB-2025-0001",
+          tracking_code: "TRACK-1001",
           report_id: "RPT1234567890",
           title: "Financial irregularities in department",
           description:
@@ -167,6 +168,7 @@ export default function EthicsOfficerDashboard() {
         {
           id: "case-2",
           case_number: "WB-2025-0002",
+          tracking_code: "TRACK-1002",
           report_id: "RPT2345678901",
           title: "Workplace harassment by supervisor",
           description: "Ongoing harassment and inappropriate behavior",
@@ -185,6 +187,7 @@ export default function EthicsOfficerDashboard() {
         {
           id: "case-3",
           case_number: "WB-2025-0003",
+          tracking_code: "TRACK-1003",
           report_id: "RPT3456789012",
           title: "Safety violations in warehouse",
           description: "Critical safety violations with injury cover-ups",
@@ -383,7 +386,7 @@ export default function EthicsOfficerDashboard() {
               Math.floor(Math.random() * 10000)
             ).padStart(4, "0")}`,
             report_id: report.report_id,
-            tracking_code: match ? match[1] : undefined,
+            tracking_code: match ? match[1] : generateTrackingCode(),
             title: extractTitleFromSummary(report.summary),
             description: report.summary,
             category: categorizeReport(report.summary, report.transcript),
@@ -457,7 +460,7 @@ export default function EthicsOfficerDashboard() {
           Math.floor(Math.random() * 10000)
         ).padStart(4, "0")}`,
         report_id: report.report_id,
-        tracking_code: match ? match[1] : undefined,
+        tracking_code: match ? match[1] : generateTrackingCode(),
         title: extractTitleFromSummary(report.summary),
         description: report.summary,
         category: categorizeReport(report.summary, report.transcript),
@@ -589,6 +592,15 @@ export default function EthicsOfficerDashboard() {
     const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     let result = "";
     for (let i = 0; i < 12; i++) {
+      result += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return result;
+  };
+
+  const generateTrackingCode = (): string => {
+    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    let result = "";
+    for (let i = 0; i < 10; i++) {
       result += chars.charAt(Math.floor(Math.random() * chars.length));
     }
     return result;
@@ -762,7 +774,7 @@ export default function EthicsOfficerDashboard() {
       // Mock email notification
       console.log("Email notification sent:", {
         to: "legal@company.com",
-        subject: `Case Escalation Required: ${selectedCase?.case_number}`,
+        subject: `Case Escalation Required: ${selectedCase?.tracking_code}`,
         body: `Case has been escalated for review.\n\nDetails:\n${escalationNote}`,
       });
 
@@ -1377,7 +1389,7 @@ export default function EthicsOfficerDashboard() {
             <DialogContent className="bg-slate-800 border-slate-700 max-w-4xl max-h-[80vh] overflow-y-auto">
               <DialogHeader>
                 <DialogTitle className="text-white">
-                  Case Details: {selectedCase.case_number}
+                  Case Details: {selectedCase.tracking_code}
                 </DialogTitle>
                 <DialogDescription className="text-slate-400">
                   Complete case information and evidence
@@ -1386,15 +1398,9 @@ export default function EthicsOfficerDashboard() {
               <div className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <Label className="text-slate-300">Case Number</Label>
+                    <Label className="text-slate-300">Case ID</Label>
                     <p className="text-white font-mono">
-                      {selectedCase.case_number}
-                    </p>
-                  </div>
-                  <div>
-                    <Label className="text-slate-300">Report ID</Label>
-                    <p className="text-white font-mono">
-                      {selectedCase.report_id}
+                      {selectedCase.tracking_code}
                     </p>
                   </div>
                 </div>
@@ -1481,7 +1487,7 @@ export default function EthicsOfficerDashboard() {
                   Assign Case to Investigator
                 </DialogTitle>
                 <DialogDescription className="text-slate-400">
-                  Select an investigator for case {selectedCase.case_number}
+                  Select an investigator for case {selectedCase.tracking_code}
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4">
@@ -1525,7 +1531,7 @@ export default function EthicsOfficerDashboard() {
               <DialogHeader>
                 <DialogTitle className="text-white">Resolve Case</DialogTitle>
                 <DialogDescription className="text-slate-400">
-                  Complete the resolution for case {selectedCase.case_number}
+                  Complete the resolution for case {selectedCase.tracking_code}
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4">
@@ -1642,7 +1648,7 @@ export default function EthicsOfficerDashboard() {
               <DialogHeader>
                 <DialogTitle className="text-white">Escalate Case</DialogTitle>
                 <DialogDescription className="text-slate-400">
-                  Escalate case {selectedCase.case_number} to legal/senior
+                  Escalate case {selectedCase.tracking_code} to legal/senior
                   management
                 </DialogDescription>
               </DialogHeader>

--- a/app/dashboard/investigator/page.tsx
+++ b/app/dashboard/investigator/page.tsx
@@ -480,7 +480,7 @@ export default function InvestigatorDashboard() {
                           Query for Case:{" "}
                           {
                             cases.find((c) => c.id === query.case_id)
-                              ?.case_number
+                              ?.tracking_code
                           }
                         </h4>
                         <Badge
@@ -542,7 +542,7 @@ export default function InvestigatorDashboard() {
                 </DialogTitle>
                 <DialogDescription className="text-slate-400">
                   Send a delicate inquiry to the whistleblower for case{" "}
-                  {selectedCase.case_number}
+                  {selectedCase.tracking_code}
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4">
@@ -589,7 +589,7 @@ export default function InvestigatorDashboard() {
                   Update Investigation
                 </DialogTitle>
                 <DialogDescription className="text-slate-400">
-                  Provide an update on case {selectedCase.case_number}
+                  Provide an update on case {selectedCase.tracking_code}
                 </DialogDescription>
               </DialogHeader>
               <div className="space-y-4">

--- a/app/dashboard/map/map-component.tsx
+++ b/app/dashboard/map/map-component.tsx
@@ -111,6 +111,7 @@ export default function MapComponent() {
     {
       id: "1",
       case_number: "CASE-001",
+      tracking_code: "TRACK-001",
       title: "Suspicious Financial Activity",
       description: "Multiple large transactions detected in employee accounts",
       category: "fraud",
@@ -134,6 +135,7 @@ export default function MapComponent() {
     {
       id: "2",
       case_number: "CASE-002",
+      tracking_code: "TRACK-002",
       title: "Workplace Harassment Report",
       description: "Employee reported verbal harassment from supervisor",
       category: "harassment",
@@ -157,6 +159,7 @@ export default function MapComponent() {
     {
       id: "3",
       case_number: "CASE-003",
+      tracking_code: "TRACK-003",
       title: "Safety Violation in Construction",
       description: "Workers not wearing required safety equipment",
       category: "safety",
@@ -180,6 +183,7 @@ export default function MapComponent() {
     {
       id: "4",
       case_number: "CASE-004",
+      tracking_code: "TRACK-004",
       title: "Discrimination Complaint",
       description: "Allegations of age discrimination in hiring process",
       category: "discrimination",
@@ -203,6 +207,7 @@ export default function MapComponent() {
     {
       id: "5",
       case_number: "CASE-005",
+      tracking_code: "TRACK-005",
       title: "Corruption Investigation",
       description: "Suspicious contract awards to specific vendors",
       category: "corruption",
@@ -464,7 +469,7 @@ export default function MapComponent() {
               color: white;
             ">
               <h3 style="margin: 0; font-size: 16px; font-weight: 600; line-height: 1.3;">${case_.title}</h3>
-              <p style="margin: 4px 0 0 0; font-size: 12px; opacity: 0.9;">Case ID: ${case_.case_number}</p>
+              <p style="margin: 4px 0 0 0; font-size: 12px; opacity: 0.9;">Case ID: ${case_.tracking_code}</p>
             </div>
             
             <div style="padding: 16px;">

--- a/app/follow-up/page.tsx
+++ b/app/follow-up/page.tsx
@@ -293,7 +293,7 @@ export default function FollowUpPage() {
 
                     </CardTitle>
                     <CardDescription className="text-slate-400">
-                      Report ID: {caseData.report_id || caseData.case_number} •
+                      Case ID: {caseData.tracking_code || caseData.report_id || caseData.case_number} •
                       Submitted:{" "}
                       {new Date(caseData.created_at).toLocaleDateString()}
                     </CardDescription>

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -26,7 +26,7 @@ export interface Case {
   priority: "low" | "medium" | "high" | "critical";
   secret_code: string;
   report_id: string; // NEW: 10-digit alphanumeric ID
-  tracking_code?: string; // NEW optional tracking code from VAPI
+  tracking_code: string; // NEW required tracking code from VAPI
   reward_amount?: number;
   recovery_amount?: number;
   reward_status: "pending" | "approved" | "paid";


### PR DESCRIPTION
## Summary
- require `tracking_code` for cases
- show tracking code in follow-up page
- display tracking codes on map markers
- update case details dialog and escalation email subject
- show tracking code when investigators view or update a case

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_683fc4b18190832fa2e883a6d2d9a378