### PR TITLE
Add env setup and stricter Supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key>
+NEXT_PUBLIC_VAPI_API_KEY=<your-vapi-api-key>
+NEXT_PUBLIC_VAPI_ASSISTANT_ID=<your-vapi-assistant-id>

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -28,3 +28,22 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+
+## Configuration
+
+1. Copy `.env.example` to `.env` and fill in your credentials:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Set the following environment variables locally or in Vercel:
+
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+   - `NEXT_PUBLIC_VAPI_API_KEY`
+   - `NEXT_PUBLIC_VAPI_ASSISTANT_ID`
+
+If the Supabase variables are missing in production, API routes will fail.

--- a/app/api/repostOnMap/route.ts
+++ b/app/api/repostOnMap/route.ts
@@ -11,6 +11,8 @@ let supabase: ReturnType<typeof createClient> | null = null
 
 if (supabaseUrl && supabaseServiceKey) {
   supabase = createClient(supabaseUrl, supabaseServiceKey)
+} else if (process.env.NODE_ENV !== 'development') {
+  throw new Error('Supabase environment variables are missing')
 } else {
   console.warn('Supabase environment variables not found. Running in test mode.')
 }
@@ -190,11 +192,17 @@ export async function POST(request: Request) {
       )
     }
 
-    // If Supabase is not configured, return a test response
+    // If Supabase is not configured
     if (!supabase) {
+      if (process.env.NODE_ENV !== 'development') {
+        return NextResponse.json(
+          { success: false, error: 'Supabase is not configured' },
+          { status: 500 }
+        )
+      }
       console.log('Test mode: Report data received:', { ...body, contactInfo: body.contactInfo ? '[REDACTED]' : undefined })
-      return NextResponse.json({ 
-        success: true, 
+      return NextResponse.json({
+        success: true,
         caseId: body.case_id,
         message: 'Report submitted successfully (test mode)',
         testMode: true,

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,11 +1,13 @@
 import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl =
-  process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  "https://vnjfnlnwfhnwzcfkdrsw.supabase.co";
-const supabaseKey =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZuamZubG53Zmhud3pjZmtkcnN3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg0NzUxNjcsImV4cCI6MjA2NDA1MTE2N30.tddKpsglas6VEWV-xMxwHcF5SASfXvWkvFyn2jDGKvM";
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error(
+    "Supabase environment variables are missing. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY."
+  );
+}
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "setup": "bash scripts/setup_env.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Simple environment setup script
+# Copies .env.example to .env if it doesn't exist.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ ! -f .env.example ]; then
+  echo "Missing .env.example" >&2
+  exit 1
+fi
+
+if [ -f .env ]; then
+  echo ".env already exists"
+else
+  cp .env.example .env
+  echo "Created .env from .env.example. Edit the file to add real values."
+fi


### PR DESCRIPTION
## Summary
- add `.env.example` with Supabase and VAPI placeholders
- document env configuration in README
- remove hard‑coded Supabase credentials and require env vars
- fail `repostOnMap` API when Supabase config is missing outside dev
- provide `scripts/setup_env.sh` and npm `setup` script
- track `.env.example` via `.gitignore` update

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683fbe32a030832fb9301af362bbbe8d